### PR TITLE
add deprecation notice: repo moved to gtm-demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> **This repository is no longer actively maintained.** The source code has been moved to [browserbase/gtm-demos](https://github.com/browserbase/gtm-demos/tree/main/apps/BrowseGPT).
+
 # BrowseGPT
 
 [BrowseGPT](https://browsegpt.dev) is a chat interface that allows you to search the web and get answers to your questions. It is built with [Vercel AI SDK](https://www.npmjs.com/package/ai) and [Browserbase](https://www.browserbase.com/).


### PR DESCRIPTION
This repository is no longer actively maintained. Source code has been moved to [browserbase/gtm-demos](https://github.com/browserbase/gtm-demos).

This PR adds a deprecation notice to the README pointing users to the new location.